### PR TITLE
aw - Copied files for Articles from team01 to team02

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,0 +1,155 @@
+package edu.ucsb.cs156.example.controllers;
+
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is a REST controller for Articles
+ */
+
+ @Tag(name = "Articles")
+ @RequestMapping("/api/articles")
+ @RestController
+ @Slf4j
+ public class ArticlesController extends ApiController {
+ 
+     @Autowired
+     ArticlesRepository articlesRepository;
+ 
+     /** 
+      * List all Articles
+      * 
+      * @return an iterable of Articles
+      */
+     @Operation(summary= "List all articles")
+     @PreAuthorize("hasRole('ROLE_USER')")
+     @GetMapping("/all")
+     public Iterable<Articles> allArticles() {
+         Iterable<Articles> articles = articlesRepository.findAll();
+         return articles;
+     }
+ 
+     /**
+      * Create a new article
+      * 
+      * @param title       title of article
+      * @param url         url to the article
+      * @param explanation description of article
+      * @param email       email of submitter
+      * @param dateAdded   the date the article was added
+      * @return the saved article
+      */
+     @Operation(summary= "Create a new article")
+     @PreAuthorize("hasRole('ROLE_ADMIN')")
+     @PostMapping("/post")
+     public Articles postArticles(
+             @Parameter(name="title") @RequestParam String title,
+             @Parameter(name="url") @RequestParam String url,
+             @Parameter(name="explanation") @RequestParam String explanation,
+             @Parameter(name="email") @RequestParam String email,
+             @Parameter(name="dateAdded", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateAdded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateAdded)
+             throws JsonProcessingException {
+ 
+         // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+         // See: https://www.baeldung.com/spring-date-parameters
+ 
+         log.info("dateAdded={}", dateAdded);
+ 
+         Articles articles = new Articles();
+         articles.setTitle(title);
+         articles.setUrl(url);
+         articles.setExplanation(explanation);
+         articles.setEmail(email);
+         articles.setDateAdded(dateAdded);
+ 
+         Articles savedArticles = articlesRepository.save(articles);
+ 
+         return savedArticles;
+     }
+
+     /**
+      * Get a single article by id
+      * 
+      * @param id the id of the articles
+      * @return a Articles
+      */
+      @Operation(summary= "Get a single article")
+      @PreAuthorize("hasRole('ROLE_USER')")
+      @GetMapping("")
+      public Articles getById(
+              @Parameter(name="id") @RequestParam Long id) {
+          Articles articles = articlesRepository.findById(id)
+                  .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+  
+          return articles;
+      }
+
+     /**
+      * Delete an Article
+      * 
+      * @param id the id of the article to delete
+      * @return a message indicating the article was deleted
+      */
+     @Operation(summary= "Delete an article")
+     @PreAuthorize("hasRole('ROLE_ADMIN')")
+     @DeleteMapping("")
+     public Object deleteArticles(
+             @Parameter(name="id") @RequestParam Long id) {
+         Articles articles = articlesRepository.findById(id)
+                 .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+ 
+         articlesRepository.delete(articles);
+         return genericMessage("Articles with id %s deleted".formatted(id));
+     }
+
+     /**
+      * Update a single article
+      * 
+      * @param id       id of the article to update
+      * @param incoming the new article
+      * @return the updated article object
+      */
+     @Operation(summary= "Update a single article")
+     @PreAuthorize("hasRole('ROLE_ADMIN')")
+     @PutMapping("")
+     public Articles updateArticles(
+             @Parameter(name="id") @RequestParam Long id,
+             @RequestBody @Valid Articles incoming) {
+ 
+         Articles articles = articlesRepository.findById(id)
+                 .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+ 
+         articles.setTitle(incoming.getTitle());
+         articles.setUrl(incoming.getUrl());
+         articles.setExplanation(incoming.getExplanation());
+         articles.setEmail(incoming.getEmail());
+         articles.setDateAdded(incoming.getDateAdded());
+ 
+         articlesRepository.save(articles);
+ 
+         return articles;
+     }
+ }
+ 

--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents Articles
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime dateAdded;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.Articles;
+
+/**
+ * The ArticlesRepository is a repository for Artciles entities.
+ */
+
+@Repository
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "arthurwu17",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ARTICLES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TITLE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_ADDED",
+                      "type": "TIMESTAMP"
+                    }
+                  }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,333 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        ArticlesRepository articlesRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/articles/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/articles/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/articles/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/articles?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        // Authorization tests for /api/articles/post
+        // (Perhaps should also have these for put and delete)
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/articles/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/articles/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-24T00:00:00");
+
+                Articles article1 = Articles.builder()
+                        .title("testarticle1")
+                        .url("testarticle1.com")
+                        .explanation("article1usedfortesting")
+                        .email("testemail1@testing.com")
+                        .dateAdded(ldt1)
+                        .build();
+
+                when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(article1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(article1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+                when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("Articles with id 7 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_articles() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-24T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("testarticle1")
+                                .url("testarticle1.com")
+                                .explanation("article1usedfortesting")
+                                .email("testemail1@testing.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2025-04-24T00:00:00");
+
+                Articles articles2 = Articles.builder()
+                                .title("testarticle2")
+                                .url("testarticle2.com")
+                                .explanation("article2usedfortesting")
+                                .email("testemail2@testing.com")
+                                .dateAdded(ldt2)
+                                .build();
+
+                ArrayList<Articles> expectedArticles = new ArrayList<>();
+                expectedArticles.addAll(Arrays.asList(articles1, articles2));
+
+                when(articlesRepository.findAll()).thenReturn(expectedArticles);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/articles/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedArticles);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_articles() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-24T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("testarticle1")
+                                .url("testarticle1.com")
+                                .explanation("article1usedfortesting")
+                                .email("testemail1@testing.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.save(eq(articles1))).thenReturn(articles1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/articles/post?title=testarticle1&url=testarticle1.com&explanation=article1usedfortesting&email=testemail1@testing.com&dateAdded=2025-04-24T00:00:00")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).save(articles1);
+                String expectedJson = mapper.writeValueAsString(articles1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_articles() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-24T00:00:00");
+                LocalDateTime ldt2 = LocalDateTime.parse("2025-04-25T00:00:00");
+
+                Articles articlesOrig = Articles.builder()
+                                .title("testarticle1")
+                                .url("testarticle1.com")
+                                .explanation("article1usedfortesting")
+                                .email("testemail1@testing.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                Articles articlesEdited = Articles.builder()
+                                .title("testarticle12")
+                                .url("testarticle2.com")
+                                .explanation("article2usedfortesting")
+                                .email("testemail2@testing.com")
+                                .dateAdded(ldt2)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(articlesEdited);
+
+                when(articlesRepository.findById(eq(67L))).thenReturn(Optional.of(articlesOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/articles?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(67L);
+                verify(articlesRepository, times(1)).save(articlesEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_articles() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-24T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("testarticle1")
+                                .url("testarticle1.com")
+                                .explanation("article1usedfortesting")
+                                .email("testemail1@testing.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(articles1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/articles?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(15L);
+                verify(articlesRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Articles with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_articles_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/articles?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Articles with id 15 not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_articles_that_does_not_exist() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2025-04-24T00:00:00");
+
+                Articles articlesEdited = Articles.builder()
+                                .title("testarticle1")
+                                .url("testarticle1.com")
+                                .explanation("article1usedfortesting")
+                                .email("testemail1@testing.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(articlesEdited);
+
+                when(articlesRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/articles?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Articles with id 67 not found", json.get("message"));
+
+        }
+}


### PR DESCRIPTION
Closes #53 

This PR copies the Articles files Articles.java, ArticlesRepository.java, ArticlesController.java, ArticlesControllerTests.java, and the database migration file from team01 to team02. This allows team02 to have the API CRUD operations for articles.
You can test these operations on localhost or dokku through swagger, and scrolling to the Articles section.
<img width="618" alt="image" src="https://github.com/user-attachments/assets/5462b5fb-1dc5-4e51-8d42-22f13936ac06" />

Dokku deployed at: https://team02-arthurwu17-dev.dokku-12.cs.ucsb.edu/