### PR TITLE
jj - ucsb dining commons menu item index page

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage.js
@@ -1,17 +1,49 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
 
-export default function UCSBDiningCommonsMenuItemsIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemTable from "main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+
+export default function UCSBDiningCommonsMenuItemIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const {
+    data: ucsbdiningcommonsmenuitems,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/ucsbdiningcommonsmenuitems/all"],
+    { method: "GET", url: "/api/ucsbdiningcommonsmenuitems/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/ucsbdiningcommonsmenuitems/create"
+          style={{ float: "right" }}
+        >
+          Create Menu Item
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/ucsbdiningcommonsmenuitems/create">Create</a>
-        </p>
-        <p>
-          <a href="/ucsbdiningcommonsmenuitems/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Menu Items</h1>
+        <UCSBDiningCommonsMenuItemTable
+          ucsbdiningcommonsmenuitems={ucsbdiningcommonsmenuitems}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage.stories.js
@@ -1,0 +1,75 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemsIndexPage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage",
+  component: UCSBDiningCommonsMenuItemsIndexPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemsIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitems/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitems/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitems/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+    }),
+    http.delete("/api/ucsbdiningcommonsmenuitems", () => {
+      return HttpResponse.json(
+        { message: "Menu Item deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage.test.js
@@ -1,15 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemsIndexPage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("UCSBDiningCommonsMenuItemsIndexPage tests", () => {
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "UCSBDiningCommonsMenuItemTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +36,22 @@ describe("UCSBDiningCommonsMenuItemsIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/ucsbdiningcommonsmenuitems/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,148 @@ describe("UCSBDiningCommonsMenuItemsIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create Menu Item/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Menu Item/);
+    expect(button).toHaveAttribute(
+      "href",
+      "/ucsbdiningcommonsmenuitems/create",
+    );
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three menu items correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/ucsbdiningcommonsmenuitems/all")
+      .reply(
+        200,
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("2");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "4",
+    );
+
+    const createMenuItemButton = screen.queryByText("Create Menu Item");
+    expect(createMenuItemButton).not.toBeInTheDocument();
+
+    const name = screen.getByText("thirdName");
+    expect(name).toBeInTheDocument();
+
+    const code = screen.getByText("thirdCode");
+    expect(code).toBeInTheDocument();
+
+    const station = screen.getByText("thirdStation");
+    expect(station).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId(
+        "UCSBDiningCommonsMenuItemTable-cell-row-0-col-Delete-button",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        "UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/ucsbdiningcommonsmenuitems/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/ucsbdiningcommonsmenuitems/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/ucsbdiningcommonsmenuitems/all")
+      .reply(
+        200,
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems,
+      );
+    axiosMock
+      .onDelete("/api/ucsbdiningcommonsmenuitems")
+      .reply(200, "Menu Item with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith("Menu Item with id 1 was deleted");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe(
+      "/api/ucsbdiningcommonsmenuitems",
+    );
+    expect(axiosMock.history.delete[0].url).toBe(
+      "/api/ucsbdiningcommonsmenuitems",
+    );
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
   });
 });


### PR DESCRIPTION
Closes #14 

MERGE AFTER #68 AND #70 

In this PR, we add the index page for UCSBDiningCommonsMenuItems.

Storybook page: https://681183add73ae95e1fafcdd1-eksenblipb.chromatic.com/?path=/story/pages-ucsbdiningcommonsmenuitems-ucsbdiningcommonsmenuitemsindexpage--empty

Dokku deployment for testing: https://team02-tizerk-dev.dokku-12.cs.ucsb.edu/

1. Login to the Dokku deployment
2. Visit the index page for Menu Items
3. Create and Delete operations should work properly

<img width="1329" alt="image" src="https://github.com/user-attachments/assets/52965b97-3dd8-45ff-bd0e-07304e2788ea" />

