### PR TITLE
jj - ucsb dining commons menu item edit page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,10 +15,10 @@ import UCSBDiningCommonsMenuItemsIndexPage from "main/pages/UCSBDiningCommonsMen
 import UCSBDiningCommonsMenuItemsCreatePage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsCreatePage";
 import UCSBDiningCommonsMenuItemsEditPage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage";
 
-
 import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemForm.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemForm.js
@@ -38,6 +38,7 @@ function UCSBDiningCommonsMenuItemForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="diningCommonsCode">diningCommonsCode</Form.Label>
         <Form.Control
+          data-testid={"UCSBDiningCommonsMenuItemForm-diningCommonsCode"}
           id="diningCommonsCode"
           type="text"
           isInvalid={Boolean(errors.diningCommonsCode)}
@@ -71,6 +72,7 @@ function UCSBDiningCommonsMenuItemForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="station">Station</Form.Label>
         <Form.Control
+          data-testid={"UCSBDiningCommonsMenuItemForm-station"}
           id="station"
           type="text"
           isInvalid={Boolean(errors.station)}
@@ -82,7 +84,12 @@ function UCSBDiningCommonsMenuItemForm({
           {errors.station?.message}
         </Form.Control.Feedback>
       </Form.Group>
-      <Button type="submit">{buttonLabel}</Button>
+      <Button
+        type="submit"
+        data-testid={"UCSBDiningCommonsMenuItemForm-submit"}
+      >
+        {buttonLabel}
+      </Button>
       <Button
         variant="Secondary"
         onClick={() => navigate(-1)}

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage.js
@@ -1,10 +1,79 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemsEditPage() {
+export default function UCSBDiningCommonsMenuItemEditPage({
+  storybook = false,
+}) {
+  let { id } = useParams();
+
+  const {
+    data: ucsbdiningcommonsmenuitem,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/ucsbdiningcommonsmenuitems?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/ucsbdiningcommonsmenuitems`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (ucsbdiningcommonsmenuitem) => ({
+    url: "/api/ucsbdiningcommonsmenuitems",
+    method: "PUT",
+    params: {
+      id: ucsbdiningcommonsmenuitem.id,
+    },
+    data: {
+      diningCommonsCode: ucsbdiningcommonsmenuitem.diningCommonsCode,
+      name: ucsbdiningcommonsmenuitem.name,
+      station: ucsbdiningcommonsmenuitem.station,
+    },
+  });
+
+  const onSuccess = (ucsbdiningcommonsmenuitem) => {
+    toast(
+      `Menu Item Updated - id: ${ucsbdiningcommonsmenuitem.id} name: ${ucsbdiningcommonsmenuitem.name}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ucsbdiningcommonsmenuitems?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsbdiningcommonsmenuitems" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Menu Item</h1>
+        {ucsbdiningcommonsmenuitem && (
+          <UCSBDiningCommonsMenuItemForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={ucsbdiningcommonsmenuitem}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage.stories.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemsEditPage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage",
+  component: UCSBDiningCommonsMenuItemsEditPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemsEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonsmenuitems", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItems[0],
+        {
+          status: 200,
+        },
+      );
+    }),
+    http.put("/api/ucsbdiningcommonsmenuitems", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+    http.put("/api/ucsbdiningcommonsmenuitems", (req) => {
+      window.alert("PUT: " + req.url + " and body: " + req.body);
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage.test.js
@@ -1,43 +1,219 @@
-import { render, screen } from "@testing-library/react";
-import UCSBDiningCommonsMenuItemsEditPage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
+import UCSBDiningCommonsMenuItemsEditPage from "main/pages/UCSBDiningCommonsMenuItems/UCSBDiningCommonsMenuItemsEditPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("UCSBDiningCommonsMenuItemsEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsbdiningcommonsmenuitems", { params: { id: 17 } })
+        .timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Menu Item");
+      expect(
+        screen.queryByTestId("UCSBDiningCommonsMenuItem-name"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBDiningCommonsMenuItemsEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/ucsbdiningcommonsmenuitems", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          diningCommonsCode: "123",
+          name: "Big Sandwich",
+          station: "Sandwich Station",
+        });
+      axiosMock.onPut("/api/ucsbdiningcommonsmenuitems").reply(200, {
+        id: "17",
+        diningCommonsCode: "456",
+        name: "Small Burger",
+        station: "Burger Station",
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonsMenuItemForm-id");
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+      const codeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+      const nameField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-name",
+      );
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-station",
+      );
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-submit",
+      );
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("Big Sandwich");
+      expect(codeField).toBeInTheDocument();
+      expect(codeField).toHaveValue("123");
+      expect(stationField).toBeInTheDocument();
+      expect(stationField).toHaveValue("Sandwich Station");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(codeField, {
+        target: { value: "456" },
+      });
+      fireEvent.change(nameField, {
+        target: { value: "Small Burger" },
+      });
+      fireEvent.change(stationField, {
+        target: { value: "Burger Station" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "Menu Item Updated - id: 17 name: Small Burger",
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/ucsbdiningcommonsmenuitems",
+      });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          diningCommonsCode: "456",
+          name: "Small Burger",
+          station: "Burger Station",
+        }),
+      ); // posted object
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonsMenuItemForm-id");
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+      const codeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+      const nameField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-name",
+      );
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-station",
+      );
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-submit",
+      );
+
+      expect(idField).toHaveValue("17");
+      expect(codeField).toHaveValue("123");
+      expect(nameField).toHaveValue("Big Sandwich");
+      expect(stationField).toHaveValue("Sandwich Station");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(codeField, { target: { value: "456" } });
+      fireEvent.change(nameField, {
+        target: { value: "Small Burger" },
+      });
+      fireEvent.change(stationField, { target: { value: "Burger Station" } });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "Menu Item Updated - id: 17 name: Small Burger",
+      );
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/ucsbdiningcommonsmenuitems",
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #15 

MERGE AFTER #67 AND #69

In this PR we replace the placeholder edit page with a working edit page for UCSBDiningCommonsMenuItems

Dokku deployment to test: https://team02-tizerk-dev.dokku-12.cs.ucsb.edu/

1. Visit the dokku deployment and login
2. Navigate to the Menu Items page
3. Click the edit button and make changes to each field
4. Click the update button and see that your changes took effect

Storybook page: https://681183add73ae95e1fafcdd1-plfojftgbv.chromatic.com/?path=/story/pages-ucsbdiningcommonsmenuitems-ucsbdiningcommonsmenuitemseditpage--default

<img width="754" alt="image" src="https://github.com/user-attachments/assets/6de63dd8-54d7-4c9a-8897-dc6b4dccb380" />
