### PR TITLE
yz-Copy files for Backend CRUD API UCSBOrganization from team01

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,132 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+/**
+ * This is a REST controller for UCSBOrganization
+ */
+
+@Tag(name = "UCSBOrganizations")
+@RequestMapping("/api/ucsborganizations")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    /**
+     * THis method returns a list of all ucsborganizations.
+     * @return a list of all ucsborganizations
+     */
+    @Operation(summary= "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrganizations() {
+        Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+        return organizations;
+    }
+
+    /**
+     * Get a single UCSBOrganization by its orgCode.
+     * @param orgCode  the primary‐key of the org
+     * @return the matching UCSBOrganization, or 404 if not found
+     */
+    @Operation(summary = "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("") 
+    public UCSBOrganization getById(
+        @Parameter(name="orgCode") @RequestParam String orgCode
+    ) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+        return org;
+    }
+
+    /**
+     * Update a single UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param id       the orgCode (String) – (@Id field)
+     * @param incoming the new organization contents
+     * @return the updated UCSBOrganization
+     */
+    @Operation(summary = "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("") 
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="id") @RequestParam(name="id") String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        org.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        org.setOrgTranslation(incoming.getOrgTranslation());
+        org.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(org);
+        return org;
+    }
+
+    /**
+     * Creates a new UCSBOrganization.  Accessible only to users with the role "ROLE_ADMIN".
+     *
+     * @param orgCode            the orgCode (String) – this will be the @Id field
+     * @param orgTranslationShort a short name/abbreviation
+     * @param orgTranslation     the full name
+     * @param inactive           whether the org is inactive
+     * @return the saved UCSBOrganization
+     */
+    @Operation(summary = "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganization(
+        @Parameter(name="orgCode") @RequestParam String orgCode,
+        @Parameter(name="orgTranslationShort") @RequestParam String orgTranslationShort,
+        @Parameter(name="orgTranslation") @RequestParam String orgTranslation,
+        @Parameter(name="inactive") @RequestParam boolean inactive
+    ) {
+
+        UCSBOrganization org = new UCSBOrganization(orgCode, orgTranslationShort, orgTranslation, inactive);
+
+        UCSBOrganization savedOrg = ucsbOrganizationRepository.save(org);
+        return savedOrg;
+    }
+
+    /**
+     * Delete a UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param id  the orgCode (String) (@Id field)
+     * @return a message indicating the organization was deleted
+     */
+    @Operation(summary = "Delete a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteOrganization(
+        @Parameter(name="id") @RequestParam(name="id") String orgCode
+    ) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(org);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -65,7 +65,7 @@ public class UCSBOrganizationController extends ApiController {
 
     /**
      * Update a single UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
-     * @param id       the orgCode (String) – (@Id field)
+     * @param orgCode       the orgCode (String) – (@Id field)
      * @param incoming the new organization contents
      * @return the updated UCSBOrganization
      */
@@ -114,7 +114,7 @@ public class UCSBOrganizationController extends ApiController {
 
     /**
      * Delete a UCSBOrganization. Accessible only to users with the role "ROLE_ADMIN".
-     * @param id  the orgCode (String) (@Id field)
+     * @param orgCode the orgCode (String) (@Id field)
      * @return a message indicating the organization was deleted
      */
     @Operation(summary = "Delete a single organization")

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity(name = "ucsborganizations")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UCSBOrganization {
+
+    @Id
+    private String orgCode;
+
+    private String orgTranslationShort;
+
+    private String orgTranslation;
+
+    private boolean inactive;
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,48 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBOrganization",
+          "author": "yxz29315",
+          "changes": [
+            {
+              "createTable": {
+                "tableName": "ucsborganizations",
+                "columns": [
+                  {
+                    "column": {
+                      "name": "org_code",
+                      "type": "varchar(64)",
+                      "constraints": { "primaryKey": true }
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "org_translation_short",
+                      "type": "varchar(255)",
+                      "constraints": { "nullable": false }
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "org_translation",
+                      "type": "varchar(255)",
+                      "constraints": { "nullable": false }
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "inactive",
+                      "type": "boolean",
+                      "constraints": { "nullable": false }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+  

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,356 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UCSBOrganizationRepository ucsbOrganizationRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for GET /api/ucsborganizations/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // Authorization tests for POST /api/ucsborganizations/post
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganizations/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganizations/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // Tests for PUT
+
+        @Test
+        public void logged_out_users_cannot_put() throws Exception {
+                mockMvc.perform(put("/api/ucsborganizations?id=whatever"))
+                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_put() throws Exception {
+                mockMvc.perform(put("/api/ucsborganizations?id=whatever"))
+                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_existing_organization() throws Exception {
+                UCSBOrganization orig = UCSBOrganization.builder()
+                .orgCode("robotics")
+                .orgTranslationShort("Robotics Club")
+                .orgTranslation("UCSB Robotics Club")
+                .inactive(false)
+                .build();
+
+                UCSBOrganization edited = UCSBOrganization.builder()
+                .orgCode("robotics")
+                .orgTranslationShort("Robo Club")
+                .orgTranslation("Gaucho Robotics Club")
+                .inactive(true)
+                .build();
+
+                String requestBody = mapper.writeValueAsString(edited);
+
+                when(ucsbOrganizationRepository.findById(eq("robotics")))
+                .thenReturn(Optional.of(orig));
+
+                MvcResult response = mockMvc.perform(
+                        put("/api/ucsborganizations?id=robotics")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).findById("robotics");
+                verify(ucsbOrganizationRepository, times(1)).save(edited);
+
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+                UCSBOrganization edited = UCSBOrganization.builder()
+                .orgCode("nope")
+                .orgTranslationShort("Nope Short")
+                .orgTranslation("No Such Organization")
+                .inactive(false)
+                .build();
+
+                String requestBody = mapper.writeValueAsString(edited);
+
+                when(ucsbOrganizationRepository.findById(eq("nope")))
+                .thenReturn(Optional.empty());
+
+                MvcResult response = mockMvc.perform(
+                        put("/api/ucsborganizations?id=nope")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).findById("nope");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id nope not found", json.get("message"));
+        }
+
+        // Functional tests for GET all
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_all_organizations() throws Exception {
+                UCSBOrganization org1 = UCSBOrganization.builder()
+                .orgCode("ieee")
+                .orgTranslationShort("IEEE at UCSB")
+                .orgTranslation("Institute of Electrical and Electronics Engineers")
+                .inactive(false)
+                .build();
+
+                UCSBOrganization org2 = UCSBOrganization.builder()
+                .orgCode("acm")
+                .orgTranslationShort("ACM at UCSB")
+                .orgTranslation("Association for Computing Machinery")
+                .inactive(true)
+                .build();
+
+                List<UCSBOrganization> allOrgs = Arrays.asList(org1, org2);
+                when(ucsbOrganizationRepository.findAll()).thenReturn(allOrgs);
+
+                MvcResult res = mockMvc.perform(get("/api/ucsborganizations/all"))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(allOrgs);
+                assertEquals(expectedJson, res.getResponse().getContentAsString());
+        }
+
+        // Functional test for POST
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_organization() throws Exception {
+                UCSBOrganization newOrg = UCSBOrganization.builder()
+                .orgCode("codesb")
+                .orgTranslationShort("CodersSB")
+                .orgTranslation("UCSB Coding Club")
+                .inactive(false)
+                .build();
+
+                when(ucsbOrganizationRepository.save(eq(newOrg))).thenReturn(newOrg);
+
+                MvcResult res = mockMvc.perform(post("/api/ucsborganizations/post")
+                                        .param("orgCode",             "codesb")
+                                        .param("orgTranslationShort", "CodersSB")
+                                        .param("orgTranslation",      "UCSB Coding Club")
+                                        .param("inactive",            "false")
+                                        .with(csrf()))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).save(newOrg);
+                String expectedJson = mapper.writeValueAsString(newOrg);
+                assertEquals(expectedJson, res.getResponse().getContentAsString());
+        }
+
+        // Functional test for POST inactive=true
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_organization_with_inactive_true() throws Exception {
+                UCSBOrganization newOrg = UCSBOrganization.builder()
+                .orgCode("chess")
+                .orgTranslationShort("Chess Club")
+                .orgTranslation("UCSB Chess Club")
+                .inactive(true)
+                .build();
+
+                when(ucsbOrganizationRepository.save(eq(newOrg))).thenReturn(newOrg);
+
+                MvcResult res = mockMvc.perform(post("/api/ucsborganizations/post")
+                                        .param("orgCode",             "chess")
+                                        .param("orgTranslationShort", "Chess Club")
+                                        .param("orgTranslation",      "UCSB Chess Club")
+                                        .param("inactive",            "true")
+                                        .with(csrf()))
+                                .andExpect(status().isOk())
+                                .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).save(newOrg);
+                String expectedJson = mapper.writeValueAsString(newOrg);
+                assertEquals(expectedJson, res.getResponse().getContentAsString());
+        }
+
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations?orgCode=doesnotmatter"))
+                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_by_id_when_it_exists() throws Exception {
+                UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("ieee")
+                .orgTranslationShort("IEEE")
+                .orgTranslation("Institute of Electrical and Electronics Engineers")
+                .inactive(false)
+                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("ieee")))
+                .thenReturn(Optional.of(org));
+
+                MvcResult result = mockMvc.perform(get("/api/ucsborganizations")
+                                        .param("orgCode", "ieee"))
+                                        .andExpect(status().isOk())
+                                        .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).findById("ieee");
+                String expectedJson = mapper.writeValueAsString(org);
+                assertEquals(expectedJson, result.getResponse().getContentAsString());
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_get_404_when_id_not_found() throws Exception {
+                when(ucsbOrganizationRepository.findById(eq("nope")))
+                .thenReturn(Optional.empty());
+
+                MvcResult result = mockMvc.perform(get("/api/ucsborganizations")
+                                        .param("orgCode", "nope"))
+                                        .andExpect(status().isNotFound())
+                                        .andReturn();
+
+                verify(ucsbOrganizationRepository, times(1)).findById("nope");
+                Map<String,Object> json = responseToJson(result);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id nope not found", json.get("message"));
+        }
+
+        // Tests for DELETE
+
+        @Test
+        public void logged_out_users_cannot_delete() throws Exception {
+                mockMvc.perform(delete("/api/ucsborganizations?id=foo")
+                        .with(csrf()))
+                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_delete() throws Exception {
+                mockMvc.perform(delete("/api/ucsborganizations?id=foo")
+                        .with(csrf()))
+                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_existing_organization() throws Exception {
+                // arrange
+                UCSBOrganization org = UCSBOrganization.builder()
+                .orgCode("robotics")
+                .orgTranslationShort("Robotics Club")
+                .orgTranslation("UCSB Robotics Club")
+                .inactive(false)
+                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("robotics")))
+                .thenReturn(Optional.of(org));
+
+                // act
+                MvcResult result = mockMvc.perform(
+                        delete("/api/ucsborganizations?id=robotics")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("robotics");
+                verify(ucsbOrganizationRepository, times(1)).delete(org);
+
+                Map<String,Object> json = responseToJson(result);
+                assertEquals("UCSBOrganization with id robotics deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_delete_nonexistent_organization() throws Exception {
+                // arrange
+                when(ucsbOrganizationRepository.findById(eq("nope")))
+                .thenReturn(Optional.empty());
+
+                // act
+                MvcResult result = mockMvc.perform(
+                        delete("/api/ucsborganizations?id=nope")
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("nope");
+
+                Map<String,Object> json = responseToJson(result);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id nope not found", json.get("message"));
+        }
+}


### PR DESCRIPTION
Closes #17 

In this PR, we copied over the CRUD operations for UCSBOrganization from team01 to team02.
The PR can be tested either on localhost or dokku by going to Swagger and checking to see the CRUD operations for UCSBOrganization

![image](https://github.com/user-attachments/assets/dafee8c5-b5b7-4f15-9073-a528b53ef2d0)

Dokku deployed: https://team02-yxz29315-dev.dokku-12.cs.ucsb.edu/