### PR TITLE
Aw articles create page

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -18,9 +18,7 @@ export default function ArticlesCreatePage({ storybook = false }) {
   });
 
   const onSuccess = (articles) => {
-    toast(
-      `New articles Created - id: ${articles.id} title: ${articles.title}`,
-    );
+    toast(`New articles Created - id: ${articles.id} title: ${articles.title}`);
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (articles) => ({
+    url: "/api/articles/post",
+    method: "POST",
+    params: {
+      title: articles.title,
+      url: articles.url,
+      explanation: articles.explanation,
+      email: articles.email,
+      dateAdded: articles.dateAdded,
+    },
+  });
+
+  const onSuccess = (articles) => {
+    toast(
+      `New articles Created - id: ${articles.id} title: ${articles.title}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/articles/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Articles</h1>
+        <ArticlesForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+export default {
+  title: "pages/Articles/ArticlesCreatePage",
+  component: ArticlesCreatePage,
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/articles/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -72,7 +72,7 @@ describe("ArticlesCreatePage tests", () => {
       dateAdded: "2022-04-20T00:00:00",
     };
 
-    axiosMock.onPost("/api/articles/post").reply(202, articles)
+    axiosMock.onPost("/api/articles/post").reply(202, articles);
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -58,16 +58,19 @@ describe("ArticlesCreatePage tests", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
     });
   });
 
   test("on submit, makes request to backend, and redirects to /articles", async () => {
     const queryClient = new QueryClient();
     const articles = {
-      id: 3,
-      name: "South Coast Deli",
-      description: "Sandwiches and Salads",
+      id: 1,
+      title: "Using testing-playground with React Testing Library",
+      url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+      explanation: "Helpful when we get to front end development",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-20T00:00:00",
     };
 
     axiosMock.onPost("/api/articles/post").reply(202, articles);
@@ -81,35 +84,60 @@ describe("ArticlesCreatePage tests", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
     });
 
-    const nameInput = screen.getByLabelText("Name");
-    expect(nameInput).toBeInTheDocument();
+    const titleInput = screen.getByLabelText("Title");
+    expect(titleInput).toBeInTheDocument();
 
-    const descriptionInput = screen.getByLabelText("Description");
-    expect(descriptionInput).toBeInTheDocument();
+    const urlInput = screen.getByLabelText("Url");
+    expect(urlInput).toBeInTheDocument();
+
+    const explanationInput = screen.getByLabelText("Explanation");
+    expect(explanationInput).toBeInTheDocument();
+
+    const emailInput = screen.getByLabelText("Email");
+    expect(emailInput).toBeInTheDocument();
+
+    const dateAddedInput = screen.getByLabelText("Date Added (iso format)");
+    expect(dateAddedInput).toBeInTheDocument();
 
     const createButton = screen.getByText("Create");
     expect(createButton).toBeInTheDocument();
 
-    fireEvent.change(nameInput, { target: { value: "South Coast Deli" } });
-    fireEvent.change(descriptionInput, {
-      target: { value: "Sandwiches and Salads" },
+    fireEvent.change(titleInput, {
+      target: { value: "Using testing-playground with React Testing Library" },
     });
+    fireEvent.change(urlInput, {
+      target: {
+        value:
+          "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+      },
+    });
+    fireEvent.change(explanationInput, {
+      target: { value: "Helpful when we get to front end development" },
+    });
+    fireEvent.change(emailInput, { target: { value: "phtcon@ucsb.edu" } });
+    fireEvent.change(dateAddedInput, {
+      target: { value: "2022-04-20T00:00:00" },
+    });
+
     fireEvent.click(createButton);
 
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     expect(axiosMock.history.post[0].params).toEqual({
-      name: "South Coast Deli",
-      description: "Sandwiches and Salads",
+      title: "Using testing-playground with React Testing Library",
+      url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+      explanation: "Helpful when we get to front end development",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-20T00:00",
     });
 
     // assert - check that the toast was called with the expected message
-    expect(mockToast).toBeCalledWith(
-      "New articles Created - id: 3 name: South Coast Deli",
+    expect(mockToast).toHaveBeenCalledWith(
+      "New articles Created - id: 1 title: Using testing-playground with React Testing Library",
     );
-    expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/articles" });
   });
 });

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("ArticlesCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("ArticlesCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,59 @@ describe("ArticlesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /articles", async () => {
+    const queryClient = new QueryClient();
+    const articles = {
+      id: 3,
+      name: "South Coast Deli",
+      description: "Sandwiches and Salads",
+    };
+
+    axiosMock.onPost("/api/articles/post").reply(202, articles);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByLabelText("Name");
+    expect(nameInput).toBeInTheDocument();
+
+    const descriptionInput = screen.getByLabelText("Description");
+    expect(descriptionInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(nameInput, { target: { value: "South Coast Deli" } });
+    fireEvent.change(descriptionInput, {
+      target: { value: "Sandwiches and Salads" },
+    });
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      name: "South Coast Deli",
+      description: "Sandwiches and Salads",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toBeCalledWith(
+      "New articles Created - id: 3 name: South Coast Deli",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/articles" });
   });
 });


### PR DESCRIPTION
Closes #58 

Merge AFTER #75 and #79 

This PR replaces the placeholder Articles Create page with a working Articles create page. 

Storybook: https://681183add73ae95e1fafcdd1-zdclywqbur.chromatic.com/?path=/story/pages-articles-articlescreatepage--default

To test, login to the dokku deployed at: https://team02-arthurwu17-dev.dokku-12.cs.ucsb.edu/
Navigate to the Articles tab and click on the Create page. 
Then input a valid articles and click the Create button.
You can check on Swagger using the api/articles/all endpoint to see that a valid articles has been created.

On dokku:
<img width="1317" alt="image" src="https://github.com/user-attachments/assets/7f9b3f00-5d3b-4b90-851e-15306d2dcf81" />

On Storybook:
<img width="1386" alt="image" src="https://github.com/user-attachments/assets/bb5d8c2b-28b1-490d-be9f-11703e939378" />

